### PR TITLE
[gogits] use `git-module` cli wrapper

### DIFF
--- a/autotag_test.go
+++ b/autotag_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gogits/git"
+	"github.com/gogits/git-module"
 )
 
 func newRepo(t *testing.T) GitRepo {
@@ -79,7 +79,9 @@ func TestAutoTag(t *testing.T) {
 
 	tags, err := r.repo.GetTags()
 	checkFatal(t, err)
-	expect := []string{"v1.0.1", "v1.0.2"}
+
+	// XXX(fujin): When switching to `git-module`, the sort order reversed. Most recent is first.
+	expect := []string{"v1.0.2", "v1.0.1"}
 
 	if !reflect.DeepEqual(expect, tags) {
 		t.Fatalf("AutoBump expected '%+v' got '%+v'\n", expect, tags)
@@ -96,7 +98,8 @@ func TestAutoTagCommits(t *testing.T) {
 
 	tags, err := r.repo.GetTags()
 	checkFatal(t, err)
-	expect := []string{"v1.0.1", "v2.0.0"}
+	// XXX(fujin): When switching to `git-module`, the sort order reversed. Most recent is first.
+	expect := []string{"v2.0.0", "v1.0.1"}
 
 	if !reflect.DeepEqual(expect, tags) {
 		t.Fatalf("AutoBump expected '%+v' got '%+v'\n", expect, tags)

--- a/git_test.go
+++ b/git_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/gogits/git"
+	"github.com/gogits/git-module"
 )
 
 func checkFatal(t *testing.T, err error) {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -10,6 +10,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/Unknwon/com",
+			"repository": "https://github.com/Unknwon/com",
+			"vcs": "git",
+			"revision": "0db4a625e949e956314d7d1adea9bf82384cc10c",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/davecgh/go-spew/spew",
 			"repository": "https://github.com/davecgh/go-spew",
 			"vcs": "git",
@@ -19,10 +27,10 @@
 			"notests": true
 		},
 		{
-			"importpath": "github.com/gogits/git",
-			"repository": "https://github.com/gogits/git",
+			"importpath": "github.com/gogits/git-module",
+			"repository": "https://github.com/gogits/git-module",
 			"vcs": "git",
-			"revision": "c62c1045b62b6d77d208e6e495890a3c2b805f1b",
+			"revision": "2a496cad1f36aed60b14844b33b68eb3edfc2718",
 			"branch": "master",
 			"notests": true
 		},
@@ -39,6 +47,14 @@
 			"repository": "https://github.com/jessevdk/go-flags",
 			"vcs": "git",
 			"revision": "0648c820cd4e564706597268ae2d2c7d9e6900c6",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/mcuadros/go-version",
+			"repository": "https://github.com/mcuadros/go-version",
+			"vcs": "git",
+			"revision": "257f7b9a7d87427c8d7f89469a5958d57f8abd7c",
 			"branch": "master",
 			"notests": true
 		}


### PR DESCRIPTION
* slight simplification of the code-base through switching to the `git-module` cli wrapper.
* remove internal `getTags` wrapping implementation.
* update of tests to reflect Reverse Sort order from library `GetTags` semantics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/autotag/6)
<!-- Reviewable:end -->
