### PR TITLE
Fix printing of the .git path when verbosity is enabled

### DIFF
--- a/autotag.go
+++ b/autotag.go
@@ -3,6 +3,7 @@ package autotag
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"sort"
 
 	"regexp"
@@ -35,8 +36,14 @@ func NewRepo(repoPath, branch string) (*GitRepo, error) {
 		return nil, fmt.Errorf("must specify a branch")
 	}
 
-	log.Println("Opening repo at ", repoPath+"/.git")
-	repo, err := git.OpenRepository(repoPath + "/.git")
+	gitDirPath, err := generateGitDirPath(repoPath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.Println("Opening repo at", gitDirPath)
+	repo, err := git.OpenRepository(gitDirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -56,6 +63,16 @@ func NewRepo(repoPath, branch string) (*GitRepo, error) {
 	}
 
 	return r, nil
+}
+
+func generateGitDirPath(repoPath string) (string, error) {
+	absolutePath, err := filepath.Abs(repoPath)
+
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(absolutePath, ".git"), nil
 }
 
 // Parse tags on repo, sort them, and store the most recent revision in the repo object


### PR DESCRIPTION
When enabling verbose output (`-v`), the first line printed is the `git`
directory being used to look up the git metadata. In `1.1.0` of autotag there is
an issue where the path has an extra space before it, as well as an extra `/`.

```
2017/05/11 00:22:51 Opening repo at  .//.git
```

This change adds a `generateGitDirPath()` function which takes the `repoPath`
and calculates the absolute path to its `.git` directory. This is then used in
the debug log line, as well as in opening the repository. The absolute path
being printed also seems to fit well with verbosity being turned-up.

In addition to the above change, an erroneous space was removed from the
printing of the log line. When using `fmt.Println()`, arguments separated by a
comma (`,`) automatically have a space added between them when the line is
printed.

Here is how it looks now:

```
2017/05/11 00:39:14 Opening repo at /Users/theckman/go/src/github.com/pantheon-systems/autotag/.git
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/autotag/12)
<!-- Reviewable:end -->
