### PR TITLE
Document how the tagging calculations are done in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ If using a recent version that depends on the Git CLI, install Git with your dis
 
 If using an older release with cgo libgit or native golang Git, the binary will work standalone.
 
+Calculating Tags
+================
+
+The `autotag` utility will use the current state of the git repository to determine what the next tag should be (when following SemVer 2.0).
+Tags created by `autotag` have the following format: `vMajor.Minor.Patch` (e.g., `v1.2.3`).
+
+By default, `autotag` only scans the `master` branch for changes. The utility first looks to find the most-recent reachable tag, only
+looking for tags that appear to be version strings. If no tags can be found the utility bails-out, so you do need to create a `v0.0.0` tag
+before using `autotag`.
+
+Once the last reachable tag has been found, the `autotag` utility inspects each commit between the tag and `HEAD` of the branch to determine
+how to increment the version. By default a single `Patch` increase is made (i.e., `v1.2.3` => `v1.2.4`). However, information can be included
+in a commit to tell `autotag` to increment the `Major` and `Minor` versions.
+
+### Incrementing Major and Minor versions
+
+When the `autotag` utility inspects the commits between the latest tag and `HEAD`, it looks for certain strings to tell it to increment
+something other than the `Patch` version. This is a simple regular expression match against your commit message.
+
+To increase your `Major` version, you can include either `[major]` or `#major` in your commit message. That means you can have the subject
+of your commit be:
+
+```
+[major] version bump in preparation for release
+```
+
+Likewise, you can include them anywhere in your commit message:
+
+```
+Fix the thing with the stuff
+
+WISOTT
+#major
+```
+
+This would result in `v1.2.3` becoming `v2.0.0`. Telling `autotag` to increase the `Minor` version is the same as with the `Major`, except
+use `[minor]` or `#minor` instead. A `Minor` version bump would result in a change from `v1.2.3` to `v1.3.0`.
+
 Usage
 =====
 


### PR DESCRIPTION
This change adds additional information to the `README.md` file to explain how
the utility calculates tags. This includes information about needing to create
an initial `v0.0.0` tag, as well as how to bump the Major and Minor versions
with information provided in your commit messages.

This should provide enough information for developers to understand how
`autotag` works and to confidently use it.

Fixes #9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/autotag/13)
<!-- Reviewable:end -->
