### PR TITLE
Add support for creating pre-release tags from last stable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,28 +58,71 @@ WISOTT
 This would result in `v1.2.3` becoming `v2.0.0`. Telling `autotag` to increase the `Minor` version is the same as with the `Major`, except
 use `[minor]` or `#minor` instead. A `Minor` version bump would result in a change from `v1.2.3` to `v1.3.0`.
 
+### Pre-Release Tags
+
+The `autotag` package supports providing a `PreReleaseName` and a `PreReleaseTimestampLayout`, which gives you the ability to automatically
+create tags like `v1.2.3-pre.20170706070042`. You can omit the name, or the timestamp, to include as much information as you'd like. The
+timestamp layout value uses the standard layout from the `time` package.
+
+This works by finding the last tag without any pre-release information, say `v1.2.3`. It then bumps the version based on the rules above,
+and appends our pre-release information on to the end starting with a hyphen. For example:
+
+* `-<PreReleaseName>`
+* `-<PreReleaseTimestamp>`
+* `-<PreReleaseName>.<PreReleaseTimestamp>`
+
+The `autotag` binary provides controlled access to this functionality by allowing you to choose one of four pre-release names, as well
+as by either using a UNIX `epoch` timestamp or a `datetime` timestamp in the form of `YYYYMMDDHHMMSS`. The `pre-release-name` is
+implemented in the `-p` flag, while the timestamp layout is implemented in the `-T` flag. See the [Usage](#Usage) section for more
+information.
+
 Usage
 =====
 
-The default behavior with no arguments will tag a new version on current repo and emit the version tagged
+The default behavior with no arguments will tag a new version on current repo and emit the version tagged:
+
 ```
 $ autotag
-v3.2.1
+3.2.1
 ```
 
-you can get more help using -h flag
+`autotag` also supports pre-release tags with the `-p` and `-T` flags, and here are some example:
+
+```
+$ autotag -p pre
+3.2.1-pre
+
+$ autotag -T epoch
+3.2.1-1499320004
+
+$ autotag -T datetime
+3.2.1-20170706054703
+
+$ autotag -p pre -T epoch
+3.2.1-pre.1499319951
+
+$ autotag -p rc -T datetime
+3.2.1-rc.20170706054528
+```
+
+
+You can get more help using the `-h/--help` flag:
+
 ```
 $ autotag -h
 Usage:
   autotag [OPTIONS]
 
 Application Options:
-  -n          Just output the next version, don't autotag
-  -v          Enable verbose logging
-  -r, --repo= Path to the repo (./)
+  -n                           Just output the next version, don't autotag
+  -v                           Enable verbose logging
+  -b, --branch=                Git branch to scan (default: master)
+  -r, --repo=                  Path to the repo (default: ./)
+  -p, --pre-release-name=      create a pre-release tag with this name (can be: alpha|beta|rc|pre|hotfix)
+  -T, --pre-release-timestamp= create a pre-release tag and append a timestamp (can be: datetime|epoch)
 
 Help Options:
-  -h, --help  Show this help message
+  -h, --help                   Show this help message
 ```
 
 Build from Source

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -12,19 +12,63 @@ import (
 
 // Options holds the CLI args
 type Options struct {
-	JustVersion bool   `short:"n" description:"Just output the next version, don't autotag"`
-	Verbose     bool   `short:"v" description:"Enable verbose logging"`
-	Branch      string `short:"b" long:"branch" description:"Git branch to scan" default:"master" `
-	RepoPath    string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
+	JustVersion         bool   `short:"n" description:"Just output the next version, don't autotag"`
+	Verbose             bool   `short:"v" description:"Enable verbose logging"`
+	Branch              string `short:"b" long:"branch" description:"Git branch to scan" default:"master" `
+	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
+	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag with this name (can be: alpha|beta|pre|rc)"`
+	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`
 }
 
 var opts Options
+
+const (
+	// epochTsLayout is the UNIX epoch time format
+	epochTsLayout = "epoch"
+
+	// datetimeTsLayout is the YYYYMMDDHHMMSS time format
+	datetimeTsLayout = "20060102150405"
+)
+
+func timestampLayoutFromOpts() string {
+	switch opts.PreReleaseTimestamp {
+	case "epoch":
+		return epochTsLayout
+	case "datetime":
+		return datetimeTsLayout
+	default:
+		return ""
+	}
+}
 
 func init() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
 		os.Exit(1)
 	}
+
+	if err := validateOpts(); err != nil {
+		log.SetOutput(os.Stderr)
+		log.Fatalf("error validating flags: %s\n", err.Error())
+	}
+}
+
+func validateOpts() error {
+	switch opts.PreReleaseName {
+	case "", "alpha", "beta", "pre", "rc":
+		// nothing -- valid values
+	default:
+		return fmt.Errorf("-p/--pre-release-name was %q; want (alpha|beta|pre|rc)", opts.PreReleaseName)
+	}
+
+	switch opts.PreReleaseTimestamp {
+	case "", "datetime", "epoch":
+		// nothing -- valid values
+	default:
+		return fmt.Errorf("-T/--pre-release-timestamp was %q; want (datetime|epoch)", opts.PreReleaseTimestamp)
+	}
+
+	return nil
 }
 
 func main() {
@@ -33,7 +77,13 @@ func main() {
 		log.SetOutput(os.Stderr)
 	}
 
-	r, err := autotag.NewRepo(opts.RepoPath, opts.Branch)
+	r, err := autotag.NewRepo(autotag.GitRepoConfig{
+		RepoPath:                  opts.RepoPath,
+		Branch:                    opts.Branch,
+		PreReleaseName:            opts.PreReleaseName,
+		PreReleaseTimestampLayout: timestampLayoutFromOpts(),
+	})
+
 	if err != nil {
 		fmt.Println("Error initializing: ", err)
 		os.Exit(1)

--- a/git_test.go
+++ b/git_test.go
@@ -93,7 +93,7 @@ func newRepoMajor(t *testing.T) GitRepo {
 	seedTestRepo(t, repo)
 	updateReadme(t, repo, "#major change")
 
-	r, err := NewRepo(repo.Path, "master")
+	r, err := NewRepo(GitRepoConfig{RepoPath: repo.Path, Branch: "master"})
 	if err != nil {
 		t.Fatal("Error creating repo", err)
 	}


### PR DESCRIPTION
This change enhances the `autotag` package to support including pre-release
information on to a generated tag. This functionality is being added to
facilitate the tagging of releases that aren't considered ready for stable
release, while being able to generate a tag that's useful for humans and
automated tooling.

**Note:** this change introduces a breaking API change to the `NewRepo()`
function. Instead of taking two string parameters, the function now takes an
`autotag.GitRepoConfig` instance. This is because we added two new user-provided
parameters to the `GitRepo` struct.

In our organization, we have the need to create releases from branches before
the merge to the stable (`master`) branch happens. This need isn't part of our
normal release workflow, and is reserved for situations where a release is
needed from a branch (think hotfix, or similar).

To accomplish the creation of pre-release tags, we added two new parameters that
can be used to configure the GitRepo:

* PreReleaseName: the `NAME` to use in the tag (e.g., `v1.2.3-NAME`)
* PreReleaseTimestampLayout the `LAYOUT` to use to generate the timestamp (e.g.,
  `v1.2.3-LAYOUT`) -- this a layout string from the `time` package

If either of these values are set, or both, a hyphen is added to the tag and the
respective values are added to the end of the tag. If these two values are
combined, and name is `test` and the layout is `epoch`, the tag would look
something like `v1.2.4-test.1499323531`.

Within the `autotag` package itself, this is done by calculating the new stable
tag (e.g., `v1.2.4`) and then appending the pre-release information to the end
of it. The `autotag` code path that determines the latest tag now explicitly
skips over tags with pre-release information attached. This is to ensure our
pre-release tags are only cut from stable ones.

Within the `autotag` binary, two more command line flags have been added:

```
-p, --pre-release-name=      create a pre-release tag with this name (can be: alpha|beta|pre|rc)
-T, --pre-release-timestamp= create a pre-release tag and append a timestamp (can be: datetime|epoch)
```

The `-p` flag allows users to specify the pre-release-name. While the `autotag`
package allows us to specify any string we want, the `autotag` binary only
accepts a subset of values to use (to promote good practices). The help output
lists the possible values.

The `-T` flag supports either setting a `datetime` (`YYYYMMDDHHMMSS`) timestamp,
or a UNIX `epoch` timestamp.

Here is an example of them being used:

```
$ autotag -n -p pre
1.1.1-pre
$ autotag -n -T epoch
1.1.1-1499320004
$ autotag -n -T datetime
1.1.1-20170706054703
$ autotag -n -p pre -T epoch
1.1.1-pre.1499319951
$ autotag -n -p pre -T datetime
1.1.1-pre.20170706054528
```

In addition to the changes made, extra tests were added to assert the new
functionality of the package. None of the older tests were changed, which
indicates the behavior of the `autotag` binary should be backwards compatible
with previous versions.

Signed-off-by: Tim Heckman <t@heckman.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/autotag/14)
<!-- Reviewable:end -->
