### PR TITLE
Allow omitting v-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Usage:
   autotag [OPTIONS]
 
 Application Options:
+  -e                           Do not prepend version with literal 'v'
   -n                           Just output the next version, don't autotag
   -v                           Enable verbose logging
   -b, --branch=                Git branch to scan (default: master)

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -18,7 +18,7 @@ type Options struct {
 	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
 	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag with this name (can be: alpha|beta|pre|rc)"`
 	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`
-	NoVersionPrefix     bool   `short:"-e" long:"empty-version-prefix" description:"do not prepend v to version tag"`
+	NoVersionPrefix     bool   `short:"e" long:"empty-version-prefix" description:"do not prepend v to version tag"`
 }
 
 var opts Options

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -18,6 +18,7 @@ type Options struct {
 	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
 	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag with this name (can be: alpha|beta|pre|rc)"`
 	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`
+	NoVersionPrefix     bool   `short:"-e" long:"empty-version-prefix" description:"do not prepend v to version tag"`
 }
 
 var opts Options
@@ -82,6 +83,7 @@ func main() {
 		Branch:                    opts.Branch,
 		PreReleaseName:            opts.PreReleaseName,
 		PreReleaseTimestampLayout: timestampLayoutFromOpts(),
+		Prefix:                    !opts.NoVersionPrefix,
 	})
 
 	if err != nil {

--- a/git_test.go
+++ b/git_test.go
@@ -85,15 +85,15 @@ func makeTag(r *git.Repository, tag string) {
 }
 
 // adds a #major comit to the repo
-func newRepoMajor(t *testing.T) GitRepo {
+func newRepoMajorPrefixToggle(t *testing.T, prefix bool) GitRepo {
 	tr := createTestRepo(t)
 
 	repo, err := git.OpenRepository(tr)
 	checkFatal(t, err)
-	seedTestRepo(t, repo)
+	seedTestRepoPrefixToggle(t, repo, prefix)
 	updateReadme(t, repo, "#major change")
 
-	r, err := NewRepo(GitRepoConfig{RepoPath: repo.Path, Branch: "master"})
+	r, err := NewRepo(GitRepoConfig{RepoPath: repo.Path, Branch: "master", Prefix: prefix})
 	if err != nil {
 		t.Fatal("Error creating repo", err)
 	}
@@ -102,6 +102,10 @@ func newRepoMajor(t *testing.T) GitRepo {
 }
 
 func seedTestRepo(t *testing.T, repo *git.Repository) {
+	seedTestRepoPrefixToggle(t, repo, true)
+}
+
+func seedTestRepoPrefixToggle(t *testing.T, repo *git.Repository, prefix bool) {
 	f := repoRoot(repo) + "/README"
 	err := exec.Command("touch", f).Run()
 	if err != nil {
@@ -110,7 +114,11 @@ func seedTestRepo(t *testing.T, repo *git.Repository) {
 	}
 
 	makeCommit(repo, "this is a commit")
-	makeTag(repo, "v1.0.1")
+	if prefix {
+		makeTag(repo, "v1.0.1")
+	} else {
+		makeTag(repo, "1.0.1")
+	}
 }
 
 func majorTag(t *testing.T, repo *git.Repository) {


### PR DESCRIPTION
Add option to not prefix ther generated versions with a literal v.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/autotag/16)
<!-- Reviewable:end -->
