### PR TITLE
use debian-slim instead of alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM alpine:latest
+FROM debian:buster-slim
 
-RUN apk add --no-cache git
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    git \
+  && apt-get autoremove --purge \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY ./autotag /autotag
 


### PR DESCRIPTION
Golang binary is compiled within CircleCI Debian based image (https://hub.docker.com/r/circleci/golang). Go binaries compiled within Debian cannot be executed within Alpine. So, it must be run into Debian based image.

References #26 