### PR TITLE
[minor] add support for SemVer build metadata (+) via -m/--build-metadata flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ AutoTag
 
 Automatically increment version tags to a git repo based on commit messages.
 
+* [AutoTag](#autotag)
+  * [Dependencies](#dependencies)
+  * [Installing](#installing)
+    * [Pre-built binaries](#pre-built-binaries)
+    * [Docker images](#docker-images)
+    * [One-liner](#one-liner)
+  * [Usage](#usage)
+    * [Scheme: Autotag (default)](#scheme-autotag-default)
+    * [Scheme: Conventional Commits](#scheme-conventional-commits)
+    * [Pre-Release Tags](#pre-release-tags)
+    * [Build metadata](#build-metadata)
+  * [Examples](#examples)
+    * [Goreleaser](#goreleaser)
+  * [Build from Source](#build-from-source)
+  * [Release information](#release-information)
+
 Dependencies
 ------------
 
@@ -23,14 +39,14 @@ Installing
 ### Pre-built binaries
 
 | OS    | Arch  | binary              |
-| ----- | ----- | ------------------- |
+|-------|-------|---------------------|
 | macOS | amd64 | [autotag][releases] |
 | Linux | amd64 | [autotag][releases] |
 
 ### Docker images
 
 | Arch  | Images                                                           |
-| ----- | ---------------------------------------------------------------- |
+|-------|------------------------------------------------------------------|
 | amd64 | `quay.io/pantheon-public/autotag:latest`, `vX.Y.Z`, `vX.Y`, `vX` |
 
 [releases]: https://github.com/pantheon-systems/autotag/releases/latest
@@ -99,7 +115,8 @@ If no keywords are specified a **Patch** bump is applied.
 
 ### Scheme: Conventional Commits
 
-Specify the [Conventional Commits](TODO) v1.0.0 scheme by passing `--scheme=conventional` to `autotag`.
+Specify the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#examples) v1.0.0
+scheme by passing `--scheme=conventional` to `autotag`.
 
 Conventional Commits implements SemVer style versioning `vMajor.Minor.Patch` similar to the
 autotag scheme, but with a different commit message format.
@@ -139,6 +156,17 @@ If no keywords are specified a **Patch** bump is applied.
 * Use `-T/--pre-release-timestmap=` to append **timestamp** to the version. Allowed timetstamp
   formats are `datetime` (YYYYMMDDHHMMSS) or `epoch` (UNIX epoch timestamp in seconds).
 
+### Build metadata
+
+Optional SemVer build metadata can be appended to the version string after a `+` character using the `-m/--build-metadata` flag. eg: `v1.2.3+foo`
+
+Build metadata is subject to the rules outlined in the [Semver](https://semver.org/#spec-item-10)
+spec.
+
+A common uses might be the current git reference: `git rev-parse --short HEAD`.
+
+Multiple metadata items should be seperated by a `.`, eg: `foo.bar`
+
 Examples
 --------
 
@@ -162,6 +190,18 @@ $ autotag -p pre -T epoch
 
 $ autotag -p rc -T datetime
 3.2.1-rc.20170706054528
+
+$ autotag -m g$(git rev-parse --short HEAD)
+3.2.1+ge92b825
+
+$ autotag -p dev -m g$(git rev-parse --short HEAD)
+3.2.1-dev+ge92b825
+
+$ autotag -m $(date +%Y%M%d)
+3.2.1-dev+20200518
+
+$ autotag  -m g$(git rev-parse --short HEAD).$(date +%s)
+3.2.1+g11492a8.1589860151
 ```
 
 For additional help information use the `-h/--help` flag:
@@ -223,10 +263,12 @@ git clone git@github.com:pantheon-systems/autotag.git
 
 cd autotag
 
+make test
 make build
 ```
 
 Release information
 -------------------
 
-Autotag itself uses `autotag` to increment releases. The default [autotag](#scheme-autotag-default) scheme is used for version selection.
+Autotag itself uses `autotag` to increment releases. The default [autotag](#scheme-autotag-default)
+scheme is used for version selection.

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -18,65 +18,18 @@ type Options struct {
 	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
 	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag with this name (can be: alpha|beta|pre|rc|dev)"`
 	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`
+	BuildMetadata       string `short:"m" long:"build-metadata" description:"optional SemVer build metadata to append to the version with '+' character"`
 	Scheme              string `short:"s" long:"scheme" description:"The commit message scheme to use (can be: autotag|conventional)" default:"autotag"`
 }
 
 var opts Options
 
-const (
-	// epochTsLayout is the UNIX epoch time format
-	epochTsLayout = "epoch"
-
-	// datetimeTsLayout is the YYYYMMDDHHMMSS time format
-	datetimeTsLayout = "20060102150405"
-)
-
-func timestampLayoutFromOpts() string {
-	switch opts.PreReleaseTimestamp {
-	case "epoch":
-		return epochTsLayout
-	case "datetime":
-		return datetimeTsLayout
-	default:
-		return ""
-	}
-}
-
 func init() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
+		log.Println(err)
 		os.Exit(1)
 	}
-
-	if err := validateOpts(); err != nil {
-		log.SetOutput(os.Stderr)
-		log.Fatalf("error validating flags: %s\n", err.Error())
-	}
-}
-
-func validateOpts() error {
-	switch opts.PreReleaseName {
-	case "", "alpha", "beta", "pre", "rc", "dev":
-		// nothing -- valid values
-	default:
-		return fmt.Errorf("-p/--pre-release-name was %q; want (alpha|beta|pre|rc|dev)", opts.PreReleaseName)
-	}
-
-	switch opts.PreReleaseTimestamp {
-	case "", "datetime", "epoch":
-		// nothing -- valid values
-	default:
-		return fmt.Errorf("-T/--pre-release-timestamp was %q; want (datetime|epoch)", opts.PreReleaseTimestamp)
-	}
-
-	switch opts.Scheme {
-	case "", "autotag", "conventional":
-		// nothing -- valid values
-	default:
-		return fmt.Errorf("-s/--scheme was %q; want (autotag|conventional)", opts.Scheme)
-	}
-
-	return nil
 }
 
 func main() {
@@ -89,9 +42,11 @@ func main() {
 		RepoPath:                  opts.RepoPath,
 		Branch:                    opts.Branch,
 		PreReleaseName:            opts.PreReleaseName,
-		PreReleaseTimestampLayout: timestampLayoutFromOpts(),
+		PreReleaseTimestampLayout: opts.PreReleaseTimestamp,
+		BuildMetadata:             opts.BuildMetadata,
 		Scheme:                    opts.Scheme,
 	})
+	log.Println("FUCK1")
 
 	if err != nil {
 		fmt.Println("Error initializing: ", err)

--- a/bumper_test.go
+++ b/bumper_test.go
@@ -9,13 +9,14 @@ import (
 // whitebox testing for autotag bump interface
 func TestMinorBumper(t *testing.T) {
 	for k, v := range map[string]string{
-		"1":      "1.1.0",
-		"1.0":    "1.1.0",
-		"1.0.0":  "1.1.0",
-		"1.0.12": "1.1.0",
-		// TODO:(jnelson) support tagging patch/build semver stuff Mon Sep 14 13:27:50 2015
-		"1.0.0-patch":    "1.1.0",
-		"1.0.0+build123": "1.1.0",
+		"1":                  "1.1.0",
+		"1.0":                "1.1.0",
+		"1.0.0":              "1.1.0",
+		"1.0.12":             "1.1.0",
+		"1.0.0-patch":        "1.1.0",
+		"1.0.0+build123":     "1.1.0",
+		"1.0.0+build123.foo": "1.1.0",
+		"1.0.0.0":            "1.1.0",
 	} {
 		tv, err := version.NewVersion(k)
 		checkFatal(t, err)
@@ -32,11 +33,13 @@ func TestMinorBumper(t *testing.T) {
 func TestPatchBumper(t *testing.T) {
 	// in retro this didn't have to be a map, but w/e
 	for k, v := range map[string]string{
-		"1":              "1.0.1",
-		"1.0":            "1.0.1",
-		"1.0.0":          "1.0.1",
-		"1.0.0-patch":    "1.0.1",
-		"1.0.0+build123": "1.0.1",
+		"1":                      "1.0.1",
+		"1.0":                    "1.0.1",
+		"1.0.0":                  "1.0.1",
+		"1.0.0-patch":            "1.0.1",
+		"1.0.0+build123":         "1.0.1",
+		"1.0.0+build123.foo.bar": "1.0.1",
+		"1.0.0.0":                "1.0.1.0", // XXX: this passes tests but is it correct? SemVer doesn't specify behavior 4 for digit versions
 	} {
 		tv, err := version.NewVersion(k)
 		checkFatal(t, err)
@@ -52,14 +55,15 @@ func TestPatchBumper(t *testing.T) {
 
 func TestMajorBumper(t *testing.T) {
 	for k, v := range map[string]string{
-		"1":              "2.0.0",
-		"1.0":            "2.0.0",
-		"1.1":            "2.0.0",
-		"1.0.0":          "2.0.0",
-		"1.1.0":          "2.0.0",
-		"1.0.0-patch":    "2.0.0",
-		"1.0.0+build123": "2.0.0",
-		"1.0.12":         "2.0.0",
+		"1":                  "2.0.0",
+		"1.0":                "2.0.0",
+		"1.1":                "2.0.0",
+		"1.0.0":              "2.0.0",
+		"1.1.0":              "2.0.0",
+		"1.0.0-patch":        "2.0.0",
+		"1.0.0+build123":     "2.0.0",
+		"1.0.0+build123.foo": "2.0.0",
+		"1.0.12":             "2.0.0",
 	} {
 		tv, err := version.NewVersion(k)
 		checkFatal(t, err)


### PR DESCRIPTION
in this commit:
- introduced support for SemVer build metadata
- moved config validation out of main and into the autotag pkg
- refactor autotag_test.go to be mostly table driven by the `TestAutoTag` func
- made time.Now() replacable during testing by adding `timeNow` package var

implements #31