### PR TITLE
fix for issue #50

### DIFF
--- a/autotag.go
+++ b/autotag.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -145,6 +146,10 @@ func NewRepo(cfg GitRepoConfig) (*GitRepo, error) {
 	gitDirPath, err := generateGitDirPath(cfg.RepoPath)
 
 	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(gitDirPath); os.IsNotExist(err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
Issue #50:

Took this route over checking error type return from upstream library due to generic return error.

Added a simple OS directory stat to validate the existence of gitRepoPath.

Tests performed:
- Tested in directory with a git repo initialized
```
ken@gnome:~/projects/nogit$ ../autotag/autotag/autotag
Error initializing:  stat /mnt/c/Users/ken/projects/nogit/.git: no such file or directory
```
- Tested in an empty directory
```
ken@gnome:~/projects/git$ ../autotag/autotag/autotag
Error initializing:  no stable (non pre-release) version tags found
```