### PR TITLE
List tags after running autotag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,7 @@ jobs:
           echo "This is merge commit, tagging"
           make build
           chmod +x ./autotag/autotag
-          ./autotag/autotag
+          ./autotag/autotag -v
           git tag -l
 
       - name: Upload Autotag Build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,6 +92,7 @@ jobs:
           make build
           chmod +x ./autotag/autotag
           ./autotag/autotag
+          git tag -l
 
       - name: Upload Autotag Build
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
`autotag` in the https://github.com/pantheon-systems/autotag/runs/2585023158 hasn't updated the git, so trying to debug that.
![image](https://user-images.githubusercontent.com/32271530/118294176-223e0d80-b4e3-11eb-9d21-be08e4eb2812.png)
