### PR TITLE
Push tags from CI flow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,11 +91,14 @@ jobs:
         # TODO: replace this with GitHub Action after #41
         run: |
           echo "This is merge commit, tagging"
+
           make build
           chmod +x ./autotag/autotag
           ./autotag/autotag -v
 
           echo "tags:" && git tag -l
+
+          git push origin --tags
 
       - name: Upload Autotag Build
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
As in #54 I thought that autotag is pushing tags to the origin and due to I have split the flow into CI and Release part it wasn't working, so for CirlceCI all work was done by the goreleaser.

Or should I merge CI and Release flow into one?