### PR TITLE
Addresses #42 by adding a CircleCI orb.

### DIFF
--- a/scripts/orb/src/executors/autotag.yaml
+++ b/scripts/orb/src/executors/autotag.yaml
@@ -1,0 +1,4 @@
+description:
+  This runs the autotag binary as an executor.
+docker:
+  - image: 'quay.io/pantheon-public/autotag:v1'

--- a/scripts/orb/src/jobs/autotag.yaml
+++ b/scripts/orb/src/jobs/autotag.yaml
@@ -1,0 +1,28 @@
+version: 2.1
+
+description: >
+  Autotag orb
+
+display:
+  home_url: "https://www.github.com/pantheon-systems/autotag.git"
+  source_url: "https://www.github.com/pantheon-systems/autotag.git"
+
+executor: autotag
+
+jobs:
+  parameters:
+    scheme:
+      type: enum
+      enum: ["autotag", "conventional"]
+      default: "autotag"
+      description: "The versioning scheme"
+  steps:
+    - checkout
+    - run:
+      name: Run autotag on the current branch.
+      command: |
+        autotag -b ${CIRCLE_BRANCH} -s <<parameters.scheme>>
+    - run:
+      name: Push the autotag changes to Github.
+      command: |
+        git push --tags


### PR DESCRIPTION
Addresses issue #42. The orb includes an autotag docker executor
as well as a job that accepts a scheme as a CircleCI parameter. The
job runs autotag on the current ${CIRCLE_BRANCH} and, if
successful, pushes the newly created tags to Github.