### PR TITLE
Avoid writing error to Stdout

### DIFF
--- a/autotag/main.go
+++ b/autotag/main.go
@@ -28,7 +28,7 @@ var opts Options
 func init() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
-		log.Println(err)
+		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }
@@ -50,7 +50,7 @@ func main() {
 	})
 
 	if err != nil {
-		fmt.Println("Error initializing: ", err)
+		fmt.Fprintf(os.Stderr, "Error initializing: %s", err.Error())
 		os.Exit(1)
 	}
 
@@ -58,7 +58,7 @@ func main() {
 	if !opts.JustVersion {
 		err = r.AutoTag()
 		if err != nil {
-			fmt.Println("Error auto updating version: ", err.Error())
+			fmt.Fprintf(os.Stderr, "Error auto updating version: %s", err.Error())
 			os.Exit(1)
 		}
 	}

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -28,7 +28,7 @@ var opts Options
 func init() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		log.Println(err)
 		os.Exit(1)
 	}
 }
@@ -50,7 +50,8 @@ func main() {
 	})
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing: %s", err.Error())
+		log.SetOutput(os.Stderr)
+		log.Println("Error initializing: " + err.Error())
 		os.Exit(1)
 	}
 
@@ -58,7 +59,8 @@ func main() {
 	if !opts.JustVersion {
 		err = r.AutoTag()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error auto updating version: %s", err.Error())
+			log.SetOutput(os.Stderr)
+			log.Println("Error auto updating version: " + err.Error())
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
In order to run this in a script, and account for a case where the tool doesn't handle (i.e. a repo without tags yet), I had hoped to pipe the output to Stderr and assign it a default value if it errors out, but that proved difficult, given that the error output was sent to Stdout. This should mitigate that.

For e.g., you should be able to do 
`version=$(shell $(AUTOTAG) -e -n 2>/dev/null), "0.0.1")`
in a Makefile to generate a tag for all cases. 