### PR TITLE
Support main branch by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Usage
 The `autotag` utility will use the current state of the git repository to determine what the next
 tag should be and then creates the tag by executing `git tag`. The `-n` flag will print the next tag but not apply it.
 
-`autotag` scans the `master` branch for commits by default. Use `-b/--branch` to scan a different
-branch. The utility first looks to find the most-recent reachable tag that matches a supported
-versioning scheme. If no tags can be found the utility bails-out, so you do need to create a
-`v0.0.0` tag before using `autotag`.
+`autotag` scans the `main` branch for commits by default. If no `main` branch is found, it will
+fall back to the `master` branch.  Use `-b/--branch` to scan a different branch. The utility first
+looks to find the most-recent reachable tag that matches a supported versioning scheme. If no tags
+can be found the utility bails-out, so you do need to create a `v0.0.0` tag before using `autotag`.
 
 Once the last reachable tag has been found, the `autotag` utility inspects each commit between the
 tag and `HEAD` of the branch to determine how to increment the version.

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -14,7 +14,7 @@ import (
 type Options struct {
 	JustVersion         bool   `short:"n" description:"Just output the next version, don't autotag"`
 	Verbose             bool   `short:"v" description:"Enable verbose logging"`
-	Branch              string `short:"b" long:"branch" description:"Git branch to scan" default:"master" `
+	Branch              string `short:"b" long:"branch" description:"Git branch to scan (defaults to main, then master)" default:""`
 	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
 	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag"`
 	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`

--- a/autotag_test.go
+++ b/autotag_test.go
@@ -51,7 +51,7 @@ type testRepoSetup struct {
 // testing the autotag package.
 // You must call cleanupTestRepo(t, r.repo) to remove the temporary directory after running tests.
 func newTestRepo(t *testing.T, setup testRepoSetup) GitRepo {
-	tr := createTestRepo(t)
+	tr := createTestRepo(t, setup.branch)
 
 	repo, err := git.Open(tr)
 	checkFatal(t, err)
@@ -224,7 +224,7 @@ func TestPatch(t *testing.T) {
 }
 
 func TestMissingInitialTag(t *testing.T) {
-	tr := createTestRepo(t)
+	tr := createTestRepo(t, "")
 	repo, err := git.Open(tr)
 	checkFatal(t, err)
 	defer cleanupTestRepo(t, repo)

--- a/autotag_test.go
+++ b/autotag_test.go
@@ -2,6 +2,7 @@ package autotag
 
 import (
 	"fmt"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -104,11 +105,6 @@ func TestValidateConfig(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name:      "missing branch",
-			cfg:       GitRepoConfig{},
-			shouldErr: true,
-		},
-		{
 			name: "invalid build metadata",
 			cfg: GitRepoConfig{
 				Branch:        "master",
@@ -173,8 +169,118 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestNewRepo(t *testing.T) {
+	var newRepoTests = []struct {
+		createBranch  string
+		requestBranch string
+		expectBranch  string
+	}{
+		{"main", "main", "main"},
+		{"main", "", "main"},
+		{"master", "master", "master"},
+		{"master", "", "master"},
+	}
+
+	for _, tt := range newRepoTests {
+		tr := createTestRepo(t, tt.createBranch)
+
+		repo, err := git.Open(tr)
+		checkFatal(t, err)
+
+		tag := "v0.0.1"
+		seedTestRepo(t, tag, repo)
+
+		r, err := NewRepo(GitRepoConfig{
+			Branch:   tt.requestBranch,
+			RepoPath: repo.Path(),
+		})
+
+		if err != nil {
+			t.Fatal("Error creating repo: ", err)
+		}
+
+		if r.branch != tt.expectBranch {
+			t.Fatalf("Expected branch %s, got [%s]", tt.expectBranch, r.branch)
+		}
+	}
+}
+
+func TestNewRepoMainAndMaster(t *testing.T) {
+	// create repo w/"master" branch
+	tr := createTestRepo(t, "master")
+
+	repo, err := git.Open(tr)
+	checkFatal(t, err)
+
+	seedTestRepo(t, "v0.0.1", repo)
+
+	// also create "main" branch
+	f := repoRoot(repo) + "/main"
+	err = exec.Command("touch", f).Run()
+	if err != nil {
+		fmt.Println("FAILED to touch the file ", f, err)
+		checkFatal(t, err)
+	}
+
+	cmd := exec.Command("git", "checkout", "-b", "main")
+	cmd.Dir = repoRoot(repo)
+	err = cmd.Run()
+	if err != nil {
+		fmt.Println("FAILED to create/checkout main branch", err)
+		checkFatal(t, err)
+	}
+
+	makeCommit(repo, "this is a commit on main")
+	makeTag(repo, "v0.2.1")
+
+	// check results
+	var newRepoTests = []struct {
+		requestBranch string
+		expectBranch  string
+	}{
+		{"main", "main"},
+		{"master", "master"},
+		{"", "main"},
+	}
+
+	for _, tt := range newRepoTests {
+		r, err := NewRepo(GitRepoConfig{
+			Branch:   tt.requestBranch,
+			RepoPath: repo.Path(),
+		})
+
+		if err != nil {
+			t.Fatal("Error creating repo: ", err)
+		}
+
+		if r.branch != tt.expectBranch {
+			t.Fatalf("Expected branch %s, got [%s]", tt.expectBranch, r.branch)
+		}
+	}
+}
+
 func TestMajor(t *testing.T) {
 	r := newTestRepo(t, testRepoSetup{
+		branch:     "master",
+		initialTag: "v1.0.1",
+	})
+	defer cleanupTestRepo(t, r.repo)
+
+	v, err := r.MajorBump()
+	if err != nil {
+		t.Fatal("MajorBump failed: ", err)
+	}
+
+	if v.String() != "2.0.0" {
+		t.Fatalf("MajorBump failed expected '2.0.0' got '%s' ", v)
+	}
+
+	fmt.Printf("Major is now %s\n", v)
+}
+
+func TestMajorWithMain(t *testing.T) {
+	r := newTestRepo(t, testRepoSetup{
+		branch:     "main",
 		initialTag: "v1.0.1",
 	})
 	defer cleanupTestRepo(t, r.repo)

--- a/git_test.go
+++ b/git_test.go
@@ -26,7 +26,7 @@ func checkFatal(t *testing.T, err error) {
 	t.Fatalf("Fail at %v:%v; %v", file, line, err)
 }
 
-func createTestRepo(t *testing.T) string {
+func createTestRepo(t *testing.T, branch string) string {
 	// figure out where we can create the test repo
 	path, err := ioutil.TempDir("", "autoTagTest")
 	checkFatal(t, err)
@@ -37,6 +37,15 @@ func createTestRepo(t *testing.T) string {
 	err = exec.Command("git", "init", path).Run()
 	if err != nil {
 		checkFatal(t, err)
+	}
+
+	// using two-step init / checkout -b to change default branch,
+	// as opposed to init.defaultBranch, which would require Git 2.28+
+	if branch != "" {
+		err := exec.Command("git", "--git-dir="+path+"/.git", "checkout", "-b", branch).Run()
+		if err != nil {
+			checkFatal(t, err)
+		}
 	}
 
 	tmpfile := "README"


### PR DESCRIPTION
Addresses #51.  When user does not specify a branch, autotag will first look for a master branch (to retain backwards compatibility), then a main branch.