### PR TITLE
surface parse commit errors in calcVersion

### DIFF
--- a/autotag.go
+++ b/autotag.go
@@ -405,7 +405,7 @@ func (r *GitRepo) calcVersion() error {
 
 		v, nerr := r.parseCommit(commit)
 		if nerr != nil {
-			log.Fatal(err)
+			log.Fatal(nerr)
 		}
 
 		if v != nil {


### PR DESCRIPTION
This was logging the wrong err