### PR TITLE
bumping yaml pkg.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -43,3 +43,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Yaml package has some known issues with older versions we were building. This package was only being used by testify, but we should update anyhow:

```
> go mod why gopkg.in/yaml.v2                                                                                                                                                                                                                             
# gopkg.in/yaml.v2
github.com/pantheon-systems/autotag
github.com/gogs/git-module
github.com/gogs/git-module.test
github.com/stretchr/testify/assert
gopkg.in/yaml.v2
```