### PR TITLE
ci: update gha workflow to allow goreleaser access to releases api

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,6 +67,9 @@ jobs:
           args: check
 
   release:
+    permissions:
+      # allow goreleaser to access the Releases API
+      contents: write
     # Checks if this is a merge into the master(main) and creates a new release if yes.
     if: github.event_name != 'pull_request'
     needs: [test, lint, goreleaser-check]


### PR DESCRIPTION
fail on main: https://github.com/pantheon-systems/autotag/actions/runs/6030202491/job/16361528671

not actually sure if this will fix it. based on: https://github.com/orgs/community/discussions/30927