### PR TITLE
Return lost underscore to name_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,11 +67,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
   # archive releases containing: binary, readme, and license. tarballs (macos, linux), zip (windows)
   - id: archives
-    name_template: >-
-      {{- .ProjectName }}_
-      _{{ .Os }}
-      {{- if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ if eq .Arch '386' }}i386{{ else }}{{ .Arch }}{{ end }}"
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
Fixes release naming broken in #100 causing install script to bail