### PR TITLE
release: add arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
   - binary: autotag
     id: macos
     main: autotag/main.go
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}}+{{.ShortCommit}}
     goos:
@@ -18,6 +20,8 @@ builds:
   - binary: autotag
     id: linux
     main: autotag/main.go
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}}+{{.ShortCommit}}
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
 
   - binary: autotag
     id: linux
@@ -23,6 +24,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
   # TODO: verify windows functionality then enable windows release binaries
   # - binary: autotag


### PR DESCRIPTION
adds arm64 binaries for darwin and linux

does _not_ add arm64 docker images. I looked into doing that w/ goreleaser and it's kind of awkward. I tried it but ran into some issues. For now, I think arm64 binaries only are fine