### PR TITLE
fix: version string comparison

### DIFF
--- a/autotag.go
+++ b/autotag.go
@@ -405,13 +405,13 @@ func (r *GitRepo) calcVersion() error {
 			log.Fatal(nerr)
 		}
 
-		if v != nil && v.String() > r.newVersion.String() {
+		if v != nil && v.GreaterThan(r.newVersion) {
 			r.newVersion = v
 		}
 	}
 
 	// if there is no movement on the version from commits, bump patch
-	if r.newVersion == r.currentVersion {
+	if r.newVersion.Equal(r.currentVersion) {
 		if r.newVersion, err = patchBumper.bump(r.currentVersion); err != nil {
 			return err
 		}

--- a/autotag_test.go
+++ b/autotag_test.go
@@ -516,6 +516,18 @@ func TestAutoTag(t *testing.T) {
 			},
 			expectedTag: "2.0.0",
 		},
+		{
+			name: "autotag scheme, version comparison is not lexicographic",
+			setup: testRepoSetup{
+				scheme:     "autotag",
+				initialTag: "v0.9.0",
+				commitList: []string{
+					"[minor]: thing 1",
+					"[minor]: thing 2",
+				},
+			},
+			expectedTag: "v0.10.0",
+		},
 
 		// tests for conventional commits scheme. Based on:
 		// https://www.conventionalcommits.org/en/v1.0.0/#summary
@@ -610,6 +622,18 @@ func TestAutoTag(t *testing.T) {
 				initialTag: "v1.0.0",
 			},
 			expectedTag: "v2.0.0",
+		},
+		{
+			name: "conventional commits, version comparison is not lexicographic",
+			setup: testRepoSetup{
+				scheme: "conventional",
+				commitList: []string{
+					"feat: thing 1",
+					"feat: thing 2",
+				},
+				initialTag: "v0.9.0",
+			},
+			expectedTag: "v0.10.0",
 		},
 	}
 


### PR DESCRIPTION
## Description

Using `>` or `<` operators for string comparison leads to lexicographical comparison, which caused a bug when a version number had to transition from single-digit to double-digit format.

To resolve this issue, utilizing the `version.Version` struct functions effectively addressed the problem.