### PR TITLE
[RELENG-284] Retire coveralls

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,11 +27,6 @@ jobs:
         run: |
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
-      - name: Install Coverage Tools
-        # TODO(vtopc): replace with Coveralls GitHub Action as this step is running for 20-30 seconds.
-        run: |
-          make deps-coverage
-
       - name: Download Dependencies
         run: |
           go mod download
@@ -41,7 +36,7 @@ jobs:
           git config --global user.email ci
           git config --global user.name ci
 
-      - name: Run Unit Tests and Upload Coverage Report
+      - name: Run Unit Tests
         run: |
           make test-gha
 

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ snapshot:
 	@goreleaser --rm-dist --snapshot --debug
 
 .PHONY:: test-gha
-test-gha:: test-go test-coveralls ## for running unit tests on GitHub Actions
+test-gha:: test-go ## for running unit tests on GitHub Actions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ AutoTag
 =======
 
 [![CI](https://github.com/pantheon-systems/autotag/actions/workflows/workflow.yml/badge.svg)](https://github.com/pantheon-systems/autotag/actions/workflows/workflow.yml)
-[![Coverage Status](https://coveralls.io/repos/github/pantheon-systems/autotag/badge.svg?branch=master)](https://coveralls.io/github/pantheon-systems/autotag?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pantheon-systems/autotag)](https://goreportcard.com/report/github.com/pantheon-systems/autotag)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
 

--- a/scripts/make/common-go.mk
+++ b/scripts/make/common-go.mk
@@ -2,7 +2,6 @@
 #
 # INPUT VARIABLES
 # - GOTEST_ARGS: Override the options passed by default ot go test (--race by default)
-# - COVERALLS_TOKEN: Token to use when pushing coverage to coveralls.
 #
 # - FETCH_CA_CERT: The presence of this variable will cause the root CA certs
 #                  to be downloaded to the file ca-certificates.crt before building.
@@ -120,10 +119,6 @@ ifeq (, $(shell which gotestcover))
 	$(call INFO, "installing gotestcover")
 	@GO111MODULE=off go get github.com/pierrre/gotestcover
 endif
-ifeq (, $(shell which goveralls))
-	$(call INFO, "installing goveralls")
-	@GO111MODULE=off go get github.com/mattn/goveralls > /dev/null
-endif
 
 deps-status:: ## check status of deps with gostatus
 ifeq (, $(shell which gostatus))
@@ -135,14 +130,6 @@ endif
 test-coverage-go:: deps-coverage ## run coverage report
 	$(call INFO, "running gotestcover")
 	@gotestcover -v -coverprofile=coverage.out $$(go list ./... | grep -v /vendor/) > /dev/null
-
-test-coveralls:: test-coverage-go ## run coverage and report to coveralls
-ifdef COVERALLS_TOKEN
-	$(call INFO, "reporting coverage to coveralls")
-	@goveralls -repotoken $$COVERALLS_TOKEN -service=circleci -coverprofile=coverage.out > /dev/null
-else
-	$(call WARN, "You asked to use Coveralls but neglected to set the COVERALLS_TOKEN environment variable")
-endif
 
 test-coverage-html:: test-coverage ## output html coverage file
 	$(call INFO, "generating html coverage report")
@@ -176,4 +163,4 @@ ifdef FETCH_CA_CERT
 	@curl -s -L https://curl.haxx.se/ca/cacert.pem -o ca-certificates.crt > /dev/null
 endif
 
-.PHONY:: _fetch-cert _gvt-install test-coverage-html test-coveralls deps-status deps-coverage deps-circle deps-go test-circle test-go build-circle build-linux build-go _go-install-dep-tools
+.PHONY:: _fetch-cert _gvt-install test-coverage-html deps-status deps-coverage deps-circle deps-go test-circle test-go build-circle build-linux build-go _go-install-dep-tools


### PR DESCRIPTION
Removed Coveralls from repo. Common-go file edited instead of replacing due to GOLANGCI_VERSION mismatch.