### PR TITLE
feat: optional support bump pre-release number

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ autotag --strict-match
 
 - Use `-T/--pre-release-timestmap=` to append **timestamp** to the version. Allowed timetstamp
   formats are `datetime` (YYYYMMDDHHMMSS) or `epoch` (UNIX epoch timestamp in seconds).
+  
+- Use `--pre-release-number` to append pre-release number to the version. Pre-release is also mentioned in the [SemVer](https://semver.org/#spec-item-9) spec. Note: `--pre-release-number` is used only when option `--pre-release-timestmap` isn't enabled.
 
 ### Build metadata
 

--- a/autotag/main.go
+++ b/autotag/main.go
@@ -18,6 +18,7 @@ type Options struct {
 	RepoPath            string `short:"r" long:"repo" description:"Path to the repo" default:"./" `
 	PreReleaseName      string `short:"p" long:"pre-release-name" description:"create a pre-release tag"`
 	PreReleaseTimestamp string `short:"T" long:"pre-release-timestamp" description:"create a pre-release tag and append a timestamp (can be: datetime|epoch)"`
+	PreReleaseNumber    bool   `long:"pre-release-number" description:"create a pre-release tag and append a pre-release number"`
 	BuildMetadata       string `short:"m" long:"build-metadata" description:"optional SemVer build metadata to append to the version with '+' character"`
 	Scheme              string `short:"s" long:"scheme" description:"The commit message scheme to use (can be: autotag|conventional)" default:"autotag"`
 	NoVersionPrefix     bool   `short:"e" long:"empty-version-prefix" description:"Do not prepend v to version tag"`
@@ -46,6 +47,7 @@ func main() {
 		Branch:                    opts.Branch,
 		PreReleaseName:            opts.PreReleaseName,
 		PreReleaseTimestampLayout: opts.PreReleaseTimestamp,
+		PreReleaseNumber:          opts.PreReleaseNumber,
 		BuildMetadata:             opts.BuildMetadata,
 		Scheme:                    opts.Scheme,
 		Prefix:                    !opts.NoVersionPrefix,


### PR DESCRIPTION
Add optional support bump pre-release number with flag `--pre-release-number`
Only increase on pre-release mode (with `--pre-release-name` and without `--pre-release-timestamp`)
For ex:
1.0.0
1.0.1-dev.1
1.0.1-dev.2
Maybe this PR will help to resolve #95 too